### PR TITLE
Feature/ch1379/update balance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The SDK provides following functions:
   - [getMappId](#getMappId)
   - [setBpiKey](#setBpiKey)
   - [getBpiKey](#getBpiKey)
+  - [getBalance](#getBalance)
 - DLT functions
   - [Faucet](#faucet)
 
@@ -274,6 +275,68 @@ This function returns a string representing the bpi key that is currently used.
 | Name     | Type   | Description                           |
 | -------- | ------ | ------------------------------------- |
 | `bpiKey` | string | String representation of the BPI key. |
+
+### getBalance
+
+Get the balance of an address or, by default, the account that is currently set.
+Usage: `overledger.dlts.dltName.getBalance(address)`
+
+#### Parameters
+
+| Name      | Type   | Description       |
+| --------- | ------ | ------------------|
+| `address` | string | Optional address. |
+
+#### Return value
+
+This function returns an object with the following fields.
+
+| Name      | Type   | Description                                                       |
+| --------- | ------ | ----------------------------------------------------------------- |
+| `dlt`     | string | The DLT which the request has been submitted to                   |
+| `address` | string | The address holding the balance                                   |
+| `unit`    | string | The unit; satoshi for bitcoin, wei for ethereum, drops for ripple |
+| `value`   | string | The amount of units this address holds                            |
+
+### getBalances
+
+Get the balances of multiple addresses
+Usage:
+
+```
+const request = [
+	{
+		"dlt": "ethereum",
+		"address": "0x0000000000000000000000000000000000000000"
+	},
+	{
+		"dlt": "ripple",
+		"address": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	}
+]
+
+overledger.getBalances(request);
+```
+
+#### Parameters
+
+This function accepts an array of objects with the following fields:
+
+| Name      | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| `dlt`     | string | The dlt where this address should be searched on |
+| `address` | string | The address for the balance query                |
+
+#### Return value
+
+This function returns an array of objects with the following fields.
+
+| Name      | Type   | Description                                                       |
+| --------- | ------ | ----------------------------------------------------------------- |
+| `dlt`     | string | The DLT which the request has been submitted to                   |
+| `address` | string | The address holding the balance                                   |
+| `unit`    | string | The unit; satoshi for bitcoin, wei for ethereum, drops for ripple |
+| `value`   | string | The amount of units this address holds                            |
 
 ### Faucet
 As per default it would take the configured address.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const overledger = new OverledgerSDK("mappId", "bpiKey", {
 
 ## Usage
 
-The SDK provides following functions:
+The SDK provides the following functions which return a standard axios response which includes the BPI data in the `data` field:
 
 - Main functions
   - [configure](#configure)
@@ -76,6 +76,7 @@ The SDK provides following functions:
   - [setBpiKey](#setBpiKey)
   - [getBpiKey](#getBpiKey)
   - [getBalance](#getBalance)
+  - [getBalances](#getBalances)
 - DLT functions
   - [Faucet](#faucet)
 
@@ -279,7 +280,8 @@ This function returns a string representing the bpi key that is currently used.
 ### getBalance
 
 Get the balance of an address or, by default, the account that is currently set.
-Usage: `overledger.dlts.dltName.getBalance(address)`
+
+Usage: `overledger.dlts.{dltName}.getBalance(address);`
 
 #### Parameters
 
@@ -385,3 +387,34 @@ In this section we will provide a description of the common object types.
 | `feeLimit`          | string | Maximum fee to pay for the transaction to be submitted on the DLT                                            |
 | `callbackUrl`       | string | Endpoint provided by the Mapp for the BPI layer to call back                                                 |
 | `signedTransaction` | string | Hexadecimal string representation of a signed transaction                                                    |
+
+
+## Usage Example
+
+In this simple usage example we will call the `getBalance` method to request the balance of the genesis address on Ripple (created by the blockchain on startup).
+
+```
+npm install @quantnetwork/overledger-sdk
+```
+
+```
+// Boilerplate
+const OverledgerSDK = require("@quantnetwork/overledger-sdk").default;
+// Replace mappId and bipKey with your own credentials.
+const overledger = new OverledgerSDK("mappId", "bpiKey", {
+  dlts: [{ dlt: "bitcoin" }, { dlt: "ethereum" }, { dlt: "ripple" }]
+});
+
+// Method call
+;(async () => {
+
+  const rippleAddress = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+  const response = await overledger.dlts.ripple.getBalance(rippleAddress);
+
+  var rippleGenesisBalance = response.data
+  // The lowest unit in XRP is called 'drop'
+  console.log("The balance of the genesis address on the Quant Ripple Testnet is", rippleGenesisBalance.value, rippleGenesisBalance.unit);
+
+})();
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const overledger = new OverledgerSDK("mappId", "bpiKey", {
 
 ## Usage
 
-The SDK provides the following functions which return a standard axios response which includes the BPI data in the `data` field:
+The SDK provides the following functions which return a promise with a standard axios response which includes the BPI data in the `data` field:
 
 - Main functions
   - [configure](#configure)

--- a/__tests__/balancesScenario.test.ts
+++ b/__tests__/balancesScenario.test.ts
@@ -1,0 +1,55 @@
+import axios from "axios";
+import OverledgerSDK from "../src";
+
+jest.mock("axios");
+
+describe("Balances", () => {
+  let overledger;
+
+  beforeAll(() => {
+    overledger = new OverledgerSDK("testmappid", "testbpikey", {
+      dlts: [
+        {
+          dlt: "bitcoin"
+        },
+        {
+          dlt: "ethereum"
+        },
+        {
+          dlt: "ripple"
+        }
+      ]
+    });
+  });
+
+  test("Can getBalances for multiple addresses", () => {
+    const array = [
+      {
+        dlt: "ethereum",
+        address: "0x0000000000000000000000000000000000000000"
+      },
+      {
+        dlt: "ripple",
+        address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+      }
+    ];
+
+    overledger.getBalances(array);
+
+    axios.post.mockResolvedValue([
+      {
+        dlt: "ethereum",
+        address: "0x0000000000000000000000000000000000000000",
+        unit: "wei",
+        value: "0"
+      },
+      {
+        dlt: "ripple",
+        address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        unit: "drop",
+        value: "202995413"
+      }
+    ]);
+    expect(axios.post).toBeCalledWith("/balances", array);
+  });
+});

--- a/__tests__/scenarioCommon.test.ts
+++ b/__tests__/scenarioCommon.test.ts
@@ -63,14 +63,11 @@ describe('Dlt/Common', () => {
         expect(axios.post).toBeCalledWith(`/faucet/fund/${dlt.type}/${newAccount.address}/10`);
       });
 
-      test('Can getBalance the setup account', () => {
+      test('Can getBalance of the setup account', () => {
         overledger.dlts[dlt.type].getBalance();
 
         axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
-        expect(axios.post).toBeCalledWith('/balances', {
-          dlt: dlt.type,
-          address: account.address,
-        });
+        expect(axios.get).toBeCalledWith(`/balances/${dlt.type}/${account.address}`);
       });
 
       test('Can getBalance an account with a specific address', () => {
@@ -78,10 +75,7 @@ describe('Dlt/Common', () => {
         overledger.dlts[dlt.type].getBalance(newAccount.address);
 
         axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
-        expect(axios.post).toBeCalledWith('/balances', {
-          dlt: dlt.type,
-          address: newAccount.address,
-        });
+        expect(axios.get).toBeCalledWith(`/balances/${dlt.type}/${newAccount.address}`);
       });
     });
   });

--- a/__tests__/scenarioCommon.test.ts
+++ b/__tests__/scenarioCommon.test.ts
@@ -1,20 +1,20 @@
-import axios from "axios";
-import OverledgerSDK from "../src";
+import axios from 'axios';
+import OverledgerSDK from '../src';
 
-jest.mock("axios");
+jest.mock('axios');
 
-describe("Dlt/Common", () => {
+describe('Dlt/Common', () => {
   [
-    { type: "ethereum", symbol: "ETH" },
-    { type: "ripple", symbol: "XRP" },
-    { type: "bitcoin", symbol: "XBT" }
+    { type: 'ethereum', symbol: 'ETH' },
+    { type: 'ripple', symbol: 'XRP' },
+    { type: 'bitcoin', symbol: 'XBT' }
   ].forEach(dlt => {
     describe(dlt.type, () => {
       let overledger;
       let account;
 
       beforeAll(() => {
-        overledger = new OverledgerSDK("testmappid", "testbpikey", {
+        overledger = new OverledgerSDK('testmappid', 'testbpikey', {
           dlts: [
             {
               dlt: dlt.type
@@ -25,74 +25,74 @@ describe("Dlt/Common", () => {
         account = overledger.dlts[dlt.type].createAccount();
       });
 
-      test("Can get name", () => {
+      test('Can get name', () => {
         expect(overledger.dlts[dlt.type].name).toBe(dlt.type);
         expect(overledger.dlts[dlt.type].symbol).toBe(dlt.symbol);
       });
 
-      test("Cannot sign a transaction without an account setup", () => {
+      test('Cannot sign a transaction without an account setup', () => {
         expect(() =>
-          overledger.dlts[dlt.type].sign(account.address, "QNT tt3")
+          overledger.dlts[dlt.type].sign(account.address, 'QNT tt3')
         ).toThrow(`The ${dlt.type} account must be setup`);
       });
 
-      test("Cannot fund without the address parameter if no account are setup", async () => {
+      test('Cannot fund without the address parameter if no account are setup', async () => {
         expect(() => overledger.dlts[dlt.type].fundAccount()).toThrow(
-          "The account must be setup"
+          'The account must be setup'
         );
       });
 
-      test("Cannot getBalance without the address parameter if no account are setup", async () => {
+      test('Cannot getBalance without the address parameter if no account are setup', async () => {
         expect(() => overledger.dlts[dlt.type].getBalance()).toThrow(
-          "The account must be setup"
+          'The account must be setup'
         );
       });
 
-      test("Can set the account previously created", () => {
+      test('Can set the account previously created', () => {
         overledger.dlts[dlt.type].setAccount(account.privateKey);
 
         expect(overledger.dlts[dlt.type].account.address).toBe(account.address);
       });
 
-      test("Can fund the setup account with a specific amount", () => {
+      test('Can fund the setup account with a specific amount', () => {
         overledger.dlts[dlt.type].fundAccount(10);
 
         axios.post.mockResolvedValue({
-          status: "ok",
-          message: "successfully added to the queue"
+          status: 'ok',
+          message: 'successfully added to the queue'
         });
         expect(axios.post).toBeCalledWith(
           `/faucet/fund/${dlt.type}/${account.address}/10`
         );
       });
 
-      test("Can fund an account with a specific amount", () => {
+      test('Can fund an account with a specific amount', () => {
         const newAccount = overledger.dlts[dlt.type].createAccount();
         overledger.dlts[dlt.type].fundAccount(10, newAccount.address);
 
         axios.post.mockResolvedValue({
-          status: "ok",
-          message: "successfully added to the queue"
+          status: 'ok',
+          message: 'successfully added to the queue'
         });
         expect(axios.post).toBeCalledWith(
           `/faucet/fund/${dlt.type}/${newAccount.address}/10`
         );
       });
 
-      test("Can getBalance of the setup account", () => {
+      test('Can getBalance of the setup account', () => {
         overledger.dlts[dlt.type].getBalance();
 
-        axios.post.mockResolvedValue({ unit: "wei", value: "0" });
+        axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
         expect(axios.get).toBeCalledWith(
           `/balances/${dlt.type}/${account.address}`
         );
       });
 
-      test("Can getBalance of an account with a specific address", () => {
+      test('Can getBalance of an account with a specific address', () => {
         const newAccount = overledger.dlts[dlt.type].createAccount();
         overledger.dlts[dlt.type].getBalance(newAccount.address);
 
-        axios.post.mockResolvedValue({ unit: "wei", value: "0" });
+        axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
         expect(axios.get).toBeCalledWith(
           `/balances/${dlt.type}/${newAccount.address}`
         );

--- a/__tests__/scenarioCommon.test.ts
+++ b/__tests__/scenarioCommon.test.ts
@@ -1,81 +1,101 @@
-import axios from 'axios';
-import OverledgerSDK from '../src';
+import axios from "axios";
+import OverledgerSDK from "../src";
 
-jest.mock('axios');
+jest.mock("axios");
 
-describe('Dlt/Common', () => {
-
+describe("Dlt/Common", () => {
   [
-    { type: 'ethereum', symbol: 'ETH' },
-    { type: 'ripple', symbol: 'XRP' },
-    { type: 'bitcoin', symbol: 'XBT' },
-  ].forEach((dlt) => {
+    { type: "ethereum", symbol: "ETH" },
+    { type: "ripple", symbol: "XRP" },
+    { type: "bitcoin", symbol: "XBT" }
+  ].forEach(dlt => {
     describe(dlt.type, () => {
-
       let overledger;
       let account;
 
       beforeAll(() => {
-        overledger = new OverledgerSDK('testmappid', 'testbpikey', {
-          dlts: [{
-            dlt: dlt.type,
-          }],
+        overledger = new OverledgerSDK("testmappid", "testbpikey", {
+          dlts: [
+            {
+              dlt: dlt.type
+            }
+          ]
         });
 
         account = overledger.dlts[dlt.type].createAccount();
       });
 
-      test('Can get name', () => {
+      test("Can get name", () => {
         expect(overledger.dlts[dlt.type].name).toBe(dlt.type);
         expect(overledger.dlts[dlt.type].symbol).toBe(dlt.symbol);
       });
 
-      test('Cannot sign a transaction without an account setup', () => {
-        expect(() => overledger.dlts[dlt.type].sign(account.address, 'QNT tt3')).toThrow(`The ${dlt.type} account must be setup`);
+      test("Cannot sign a transaction without an account setup", () => {
+        expect(() =>
+          overledger.dlts[dlt.type].sign(account.address, "QNT tt3")
+        ).toThrow(`The ${dlt.type} account must be setup`);
       });
 
-      test('Cannot fund without the address parameter if no account are setup', async () => {
-        expect(() => overledger.dlts[dlt.type].fundAccount()).toThrow('The account must be setup');
+      test("Cannot fund without the address parameter if no account are setup", async () => {
+        expect(() => overledger.dlts[dlt.type].fundAccount()).toThrow(
+          "The account must be setup"
+        );
       });
 
-      test('Cannot getBalance without the address parameter if no account are setup', async () => {
-        expect(() => overledger.dlts[dlt.type].getBalance()).toThrow('The account must be setup');
+      test("Cannot getBalance without the address parameter if no account are setup", async () => {
+        expect(() => overledger.dlts[dlt.type].getBalance()).toThrow(
+          "The account must be setup"
+        );
       });
 
-      test('Can set the account previously created', () => {
+      test("Can set the account previously created", () => {
         overledger.dlts[dlt.type].setAccount(account.privateKey);
 
         expect(overledger.dlts[dlt.type].account.address).toBe(account.address);
       });
 
-      test('Can fund the setup account with a specific amount', () => {
+      test("Can fund the setup account with a specific amount", () => {
         overledger.dlts[dlt.type].fundAccount(10);
 
-        axios.post.mockResolvedValue({ status: 'ok', message: 'successfully added to the queue' });
-        expect(axios.post).toBeCalledWith(`/faucet/fund/${dlt.type}/${account.address}/10`);
+        axios.post.mockResolvedValue({
+          status: "ok",
+          message: "successfully added to the queue"
+        });
+        expect(axios.post).toBeCalledWith(
+          `/faucet/fund/${dlt.type}/${account.address}/10`
+        );
       });
 
-      test('Can fund an account with a specific amount', () => {
+      test("Can fund an account with a specific amount", () => {
         const newAccount = overledger.dlts[dlt.type].createAccount();
         overledger.dlts[dlt.type].fundAccount(10, newAccount.address);
 
-        axios.post.mockResolvedValue({ status: 'ok', message: 'successfully added to the queue' });
-        expect(axios.post).toBeCalledWith(`/faucet/fund/${dlt.type}/${newAccount.address}/10`);
+        axios.post.mockResolvedValue({
+          status: "ok",
+          message: "successfully added to the queue"
+        });
+        expect(axios.post).toBeCalledWith(
+          `/faucet/fund/${dlt.type}/${newAccount.address}/10`
+        );
       });
 
-      test('Can getBalance of the setup account', () => {
+      test("Can getBalance of the setup account", () => {
         overledger.dlts[dlt.type].getBalance();
 
-        axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
-        expect(axios.get).toBeCalledWith(`/balances/${dlt.type}/${account.address}`);
+        axios.post.mockResolvedValue({ unit: "wei", value: "0" });
+        expect(axios.get).toBeCalledWith(
+          `/balances/${dlt.type}/${account.address}`
+        );
       });
 
-      test('Can getBalance an account with a specific address', () => {
+      test("Can getBalance of an account with a specific address", () => {
         const newAccount = overledger.dlts[dlt.type].createAccount();
         overledger.dlts[dlt.type].getBalance(newAccount.address);
 
-        axios.post.mockResolvedValue({ unit: 'wei', value: '0' });
-        expect(axios.get).toBeCalledWith(`/balances/${dlt.type}/${newAccount.address}`);
+        axios.post.mockResolvedValue({ unit: "wei", value: "0" });
+        expect(axios.get).toBeCalledWith(
+          `/balances/${dlt.type}/${newAccount.address}`
+        );
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8782,27 +8782,8 @@
       "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "web3-core-helpers": "1.0.0-beta.36",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {
@@ -8842,6 +8823,26 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -9074,6 +9075,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/src/dlts/AbstractDlt.ts
+++ b/src/dlts/AbstractDlt.ts
@@ -137,10 +137,7 @@ abstract class AbstractDLT {
       address = this.account.address;
     }
 
-    return this.sdk.request.post('/balances', {
-      address,
-      dlt: this.name,
-    });
+    return this.sdk.request.get(`/balances/${this.name}/${address}`);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,11 @@ class OverledgerSDK {
   public getBpiKey(): string {
     return this.bpiKey;
   }
+
+  public getBalances(array): AxiosPromise<Object> {
+
+    return this.request.post('/balances', array);
+  }
 }
 
 export type SignedTransactionResponse = {


### PR DESCRIPTION
Currently, the SDK includes an older version of the `getBalance` BPI request which accepted a single object of the type { "dlt", "address" } and returned an object of the type { "unit", "value" }.

This update splits the function in two different ones: `getBalance` and `getBalances`.

`getBalance` will do a GET request to `bpi.overledger.io/balances/{dlt}/{address}`.
`getBalances` will issue a POST request to `bpi.overledger.io/balances` with a body composed of an array of objects of the { "dlt", "address" } type.

Responses have been updated in both functions to include { "dlt", "address", "unit", "value"}.

The documentation has been updated to include a usage example, along with a mention that the BPI data of the http responses will be located in the 'data' field.