### PR TITLE
Switch fund amount type to string, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Example of DLT transaction data:
     options: {
       amount: '1', // amount in drop
       feePrice: '10',
-      sequence: 1,
+      sequence: 1, // transaction index number for this account (e.g if it's the first transaction after funding the address, sequence is 1)
       maxLedgerVersion: '4294967295',
     }
   }
@@ -366,13 +366,14 @@ Usage: `fundAccount(amount?, address?)`
 
 #### Parameters
 
-This function takes:
-- amount: **OPTIONAL** the dlt amount must be the lowest decimal available; ie. for bitcoin in satoshi, ripple in drops and ethereum in wei
-- address: **OPTIONAL** the dlt address.
+| Name      | Type   | Description                                                                                                               |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `amount`  | string | _Optional_ The amount of tokens to fund, in the smallest unit (satoshi for Bitcoin, wei for Ethereum or drops for Ripple) |
+| `address` | string | _Optional_ The address to fund                                                                                            |
 
 #### Return Value
 
-This function returns `Promise`
+This function returns a `Promise`
 
 
 ## Types

--- a/__tests__/scenarioBitcoin.test.ts
+++ b/__tests__/scenarioBitcoin.test.ts
@@ -25,7 +25,7 @@ describe('Dlt/Bitcoin', () => {
     expect(account.address.length).toBe(34);
   });
 
-  test('Can fund the setup account with the default amount', () => {
+  test('Can fund the set up account with the default amount', () => {
     overledger.dlts.bitcoin.fundAccount();
 
     axios.post.mockResolvedValue({ status: 'OK',
@@ -39,11 +39,11 @@ describe('Dlt/Bitcoin', () => {
   });
 
   test('Cannot sign a bitcoin transaction without specifying a sequence', () => {
-    expect(() => overledger.dlts.bitcoin.sign('2NFj2CVhE5ru7werwXUNCbirUW6KDo2d', 'QNT tt3')).toThrow('options.sequence must be setup');
+    expect(() => overledger.dlts.bitcoin.sign('2NFj2CVhE5ru7werwXUNCbirUW6KDo2d', 'QNT tt3')).toThrow('options.sequence must be set up');
   });
 
   test('Cannot sign a bitcoin transaction without specifying a previousTransactionHash', () => {
-    expect(() => overledger.dlts.bitcoin.sign('2NFj2CVhE5ru7werwXUNCbirUW6KDo2d', 'QNT tt3', { sequence: 1 })).toThrow('options.previousTransactionHash must be setup');
+    expect(() => overledger.dlts.bitcoin.sign('2NFj2CVhE5ru7werwXUNCbirUW6KDo2d', 'QNT tt3', { sequence: 1 })).toThrow('options.previousTransactionHash must be set up');
   });
 
   // @TODO: Needs to be fix

--- a/__tests__/scenarioCommon.test.ts
+++ b/__tests__/scenarioCommon.test.ts
@@ -30,21 +30,21 @@ describe('Dlt/Common', () => {
         expect(overledger.dlts[dlt.type].symbol).toBe(dlt.symbol);
       });
 
-      test('Cannot sign a transaction without an account setup', () => {
+      test('Cannot sign a transaction without an account set up', () => {
         expect(() =>
           overledger.dlts[dlt.type].sign(account.address, 'QNT tt3')
-        ).toThrow(`The ${dlt.type} account must be setup`);
+        ).toThrow(`The ${dlt.type} account must be set up`);
       });
 
-      test('Cannot fund without the address parameter if no account are setup', async () => {
+      test('Cannot fund without the address parameter if no account are set up', async () => {
         expect(() => overledger.dlts[dlt.type].fundAccount()).toThrow(
-          'The account must be setup'
+          'The account must be set up'
         );
       });
 
-      test('Cannot getBalance without the address parameter if no account are setup', async () => {
+      test('Cannot getBalance without the address parameter if no account are set up', async () => {
         expect(() => overledger.dlts[dlt.type].getBalance()).toThrow(
-          'The account must be setup'
+          'The account must be set up'
         );
       });
 
@@ -54,8 +54,8 @@ describe('Dlt/Common', () => {
         expect(overledger.dlts[dlt.type].account.address).toBe(account.address);
       });
 
-      test('Can fund the setup account with a specific amount', () => {
-        overledger.dlts[dlt.type].fundAccount(10);
+      test('Can fund the set up account with a specific amount', () => {
+        overledger.dlts[dlt.type].fundAccount('10');
 
         axios.post.mockResolvedValue({
           status: 'ok',
@@ -68,7 +68,7 @@ describe('Dlt/Common', () => {
 
       test('Can fund an account with a specific amount', () => {
         const newAccount = overledger.dlts[dlt.type].createAccount();
-        overledger.dlts[dlt.type].fundAccount(10, newAccount.address);
+        overledger.dlts[dlt.type].fundAccount('10', newAccount.address);
 
         axios.post.mockResolvedValue({
           status: 'ok',
@@ -79,7 +79,7 @@ describe('Dlt/Common', () => {
         );
       });
 
-      test('Can getBalance of the setup account', () => {
+      test('Can getBalance of the set up account', () => {
         overledger.dlts[dlt.type].getBalance();
 
         axios.post.mockResolvedValue({ unit: 'wei', value: '0' });

--- a/__tests__/scenarioEthereum.test.ts
+++ b/__tests__/scenarioEthereum.test.ts
@@ -24,7 +24,7 @@ describe('Dlt/Ethereum', () => {
     expect(account.address.length).toBe(42);
   });
 
-  test('Can fund the setup account with the default amount', () => {
+  test('Can fund the set up account with the default amount', () => {
     overledger.dlts.ethereum.fundAccount();
 
     axios.post.mockResolvedValue({ status: 'ok', message: 'successfully added to the queue' });
@@ -32,26 +32,26 @@ describe('Dlt/Ethereum', () => {
   });
 
   test('Cannot sign an ethereum transaction without specifying an amount', () => {
-    expect(() => overledger.dlts.ethereum.sign('0x0000000000000000000000000000000000000000', 'QNT tt3')).toThrow('options.amount must be setup');
+    expect(() => overledger.dlts.ethereum.sign('0x0000000000000000000000000000000000000000', 'QNT tt3')).toThrow('options.amount must be set up');
   });
 
   test('Cannot sign an ethereum transaction without specifying an feeLimit', () => {
 
     expect(() => overledger.dlts.ethereum.sign('0x0000000000000000000000000000000000000000', 'QNT tt3', {
       amount: 0,
-    })).toThrow('options.feeLimit must be setup');
+    })).toThrow('options.feeLimit must be set up');
   });
 
   test('Cannot sign an ethereum transaction without specifying an feePrice', () => {
     expect(() => overledger.dlts.ethereum.sign('0x0000000000000000000000000000000000000000', 'QNT tt3', {
       amount: 0, feeLimit: 100,
-    })).toThrow('options.feePrice must be setup');
+    })).toThrow('options.feePrice must be set up');
   });
 
   test('Cannot sign an ethereum transaction without specifying a sequence', () => {
     expect(() => overledger.dlts.ethereum.sign('0x0000000000000000000000000000000000000000', 'QNT tt3', {
       amount: 0, feeLimit: 100, feePrice: 1,
-    })).toThrow('options.sequence must be setup');
+    })).toThrow('options.sequence must be set up');
   });
 
   test('Can sign an ethereum transaction', async () => {

--- a/__tests__/scenarioRipple.test.ts
+++ b/__tests__/scenarioRipple.test.ts
@@ -24,7 +24,7 @@ describe('Dlt/Ripple', () => {
     expect(account.address).toMatch(/r[1-9A-HJ-NP-Za-km-z]{25,34}/);
   });
 
-  test('Can fund the setup account with the default amount', () => {
+  test('Can fund the set up account with the default amount', () => {
     overledger.dlts.ripple.fundAccount();
 
     axios.post.mockResolvedValue({ status: 'OK',
@@ -38,25 +38,25 @@ describe('Dlt/Ripple', () => {
   });
 
   test('Cannot sign a ripple transaction without specifying an amount', () => {
-    expect(() => overledger.dlts.ripple.sign('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'QNT tt3')).toThrow('options.amount must be setup');
+    expect(() => overledger.dlts.ripple.sign('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'QNT tt3')).toThrow('options.amount must be set up');
   });
 
   test('Cannot sign a ripple transaction without specifying a feePrice', () => {
     expect(() => overledger.dlts.ripple.sign('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'QNT tt3', {
       amount: '1',
-    })).toThrow('options.feePrice must be setup');
+    })).toThrow('options.feePrice must be set up');
   });
 
   test('Cannot sign a ripple transaction without specifying a sequence', () => {
     expect(() => overledger.dlts.ripple.sign('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'QNT tt3', {
       amount: '1', feePrice: '0.000012',
-    })).toThrow('options.sequence must be setup');
+    })).toThrow('options.sequence must be set up');
   });
 
   test('Cannot sign a ripple transaction without specifying a maxLedgerVersion', () => {
     expect(() => overledger.dlts.ripple.sign('rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh', 'QNT tt3', {
       amount: '1', feePrice: '0.000012', sequence: '1',
-    })).toThrow('options.maxLedgerVersion must be setup');
+    })).toThrow('options.maxLedgerVersion must be set up');
   });
 
   test('Can sign a ripple transaction', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2920,8 +2920,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2942,14 +2941,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2964,20 +2961,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3094,8 +3088,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3107,7 +3100,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3122,7 +3114,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3130,14 +3121,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3156,7 +3145,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3237,8 +3225,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3250,7 +3237,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3336,8 +3322,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3373,7 +3358,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3393,7 +3377,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3437,14 +3420,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8802,7 +8783,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.36",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {

--- a/src/dlts/AbstractDlt.ts
+++ b/src/dlts/AbstractDlt.ts
@@ -26,7 +26,7 @@ abstract class AbstractDLT {
    */
   public sign(toAddress: string, message: string, options: TransactionOptions = {}): Promise<string> {
     if (!this.account) {
-      throw new Error(`The ${this.name} account must be setup`);
+      throw new Error(`The ${this.name} account must be set up`);
     }
 
     return this._sign(toAddress, message, options);
@@ -108,13 +108,17 @@ abstract class AbstractDLT {
   /**
    * Fund an account
    *
-   * @param {number} amount The amount to fund
+   * @param {string} amount The amount to fund
    * @param {string} address the address to fund
    */
-  fundAccount(amount: number, address: string = null): Promise<AxiosResponse> {
+  fundAccount(amount: string, address: string = null): Promise<AxiosResponse> {
+    if (typeof amount !== 'string') {
+      throw new Error('The amount parameter must be of type string');
+    }
+    
     if (address === null) {
       if (!this.account) {
-        throw new Error('The account must be setup');
+        throw new Error('The account must be set up');
       }
 
       address = this.account.address;
@@ -131,7 +135,7 @@ abstract class AbstractDLT {
   getBalance(address: string = null): Promise<AxiosResponse> {
     if (address === null) {
       if (!this.account) {
-        throw new Error('The account must be setup');
+        throw new Error('The account must be set up');
       }
 
       address = this.account.address;

--- a/src/dlts/Bitcoin.ts
+++ b/src/dlts/Bitcoin.ts
@@ -42,11 +42,11 @@ class Bitcoin extends AbstractDLT {
     // @TODO: add option statement
   buildTransaction(toAddress: string, message: string, options: TransactionOptions): any {
     if (typeof options.sequence === 'undefined') {
-      throw new Error('options.sequence must be setup');
+      throw new Error('options.sequence must be set up');
     }
 
     if (typeof options.previousTransactionHash === 'undefined') {
-      throw new Error('options.previousTransactionHash must be setup');
+      throw new Error('options.previousTransactionHash must be set up');
     }
 
     const tx = new bitcoin.TransactionBuilder(this.addressType);
@@ -102,7 +102,7 @@ class Bitcoin extends AbstractDLT {
   /**
    * @inheritdoc
    */
-  fundAccount(amount: number = 1e8, address: string = null): Promise<AxiosResponse> {
+  fundAccount(amount: string = '100000000', address: string = null): Promise<AxiosResponse> {
     return super.fundAccount(amount, address);
   }
 }

--- a/src/dlts/Ethereum.ts
+++ b/src/dlts/Ethereum.ts
@@ -49,19 +49,19 @@ class Ethereum extends AbstractDLT {
    */
   buildTransaction(toAddress: string, message: string, options: TransactionOptions): Transaction {
     if (typeof options.amount === 'undefined') {
-      throw new Error('options.amount must be setup');
+      throw new Error('options.amount must be set up');
     }
 
     if (typeof options.feeLimit === 'undefined') {
-      throw new Error('options.feeLimit must be setup');
+      throw new Error('options.feeLimit must be set up');
     }
 
     if (typeof options.feePrice === 'undefined') {
-      throw new Error('options.feePrice must be setup');
+      throw new Error('options.feePrice must be set up');
     }
 
     if (typeof options.sequence === 'undefined') {
-      throw new Error('options.sequence must be setup');
+      throw new Error('options.sequence must be set up');
     }
 
     const transaction = {
@@ -115,7 +115,7 @@ class Ethereum extends AbstractDLT {
   /**
    * @inheritdoc
    */
-  fundAccount(amount: number = 1e18, address: string = null): Promise<AxiosResponse> {
+  fundAccount(amount: string = '1000000000000000000', address: string = null): Promise<AxiosResponse> {
     return super.fundAccount(amount, address);
   }
 }

--- a/src/dlts/Ripple.ts
+++ b/src/dlts/Ripple.ts
@@ -45,16 +45,16 @@ class Ripple extends AbstractDlt {
    */
   buildTransaction(toAddress: string, message: string, options: TransactionOptions): Transaction {
     if (typeof options.amount === 'undefined') {
-      throw new Error('options.amount must be setup');
+      throw new Error('options.amount must be set up');
     }
     if (typeof options.feePrice === 'undefined') {
-      throw new Error('options.feePrice must be setup');
+      throw new Error('options.feePrice must be set up');
     }
     if (typeof options.sequence === 'undefined') {
-      throw new Error('options.sequence must be setup');
+      throw new Error('options.sequence must be set up');
     }
     if (typeof options.maxLedgerVersion === 'undefined') {
-      throw new Error('options.maxLedgerVersion must be setup');
+      throw new Error('options.maxLedgerVersion must be set up');
     }
     const amountInXRP = dropsToXrp(options.amount);
 
@@ -135,7 +135,7 @@ class Ripple extends AbstractDlt {
   /**
    * @inheritdoc
    */
-  fundAccount(amount: number = 1e9, address: string = null): Promise<AxiosResponse> {
+  fundAccount(amount: string = '1000000000', address: string = null): Promise<AxiosResponse> {
     return super.fundAccount(amount, address);
   }
 }


### PR DESCRIPTION
Story details: https://app.clubhouse.io/quantnetwork/story/2261/

Summary: changes the `amount` param of `fundAccount(amount: number, address: string)` from number to string, in order to overcome unintended effects.