### PR TITLE
add subType.name to Ethereum smart contract options

### DIFF
--- a/examples/smart-contracts/create-smart-contract.js
+++ b/examples/smart-contracts/create-smart-contract.js
@@ -51,7 +51,7 @@ const smartContractDemoCode = "0x60806040523480156200001157600080fd5b50604051620
             //the following parameters are from the TransactionRequest object:
         dlt: DltNameOptions.ethereum,
         type: TransactionTypeOptions.accounts,
-        subType: TransactionEthereumSubTypeOptions.smartContractDeploy,
+        subType: {name: TransactionEthereumSubTypeOptions.smartContractDeploy},
         message: "",  //This must be empty for a contractDeploy transaction
             //the following parameters are from the TransactionAccountRequest object:
         fromAddress: partyAEthereumAddress,

--- a/examples/smart-contracts/invoke-smart-contract.js
+++ b/examples/smart-contracts/invoke-smart-contract.js
@@ -46,7 +46,7 @@ const smartContractAddress = '0x1BA73B0aE8CfB686f2C6Fa21571018Bca48Ec89d';
             //the following parameters are from the TransactionRequest object:
         dlt: DltNameOptions.ethereum,
         type: TransactionTypeOptions.accounts,
-        subType: TransactionEthereumSubTypeOptions.smartContractInvocation,
+        subType: {name: TransactionEthereumSubTypeOptions.smartContractInvocation},
         message: "",  //This must be empty for a contractInvocation transaction
             //the following parameters are from the TransactionAccountRequest object:
         fromAddress: partyAEthereumAddress,


### PR DESCRIPTION
Small change for the example subType.name is used instead of subType