### PR TITLE
adding these back again

### DIFF
--- a/examples/fee-estimation/fee-estimation.js
+++ b/examples/fee-estimation/fee-estimation.js
@@ -1,0 +1,52 @@
+const OverledgerSDK = require('@quantnetwork/overledger-bundle/dist').default;
+const DltNameOptions = require('@quantnetwork/overledger-types').DltNameOptions;
+
+//  ---------------------------------------------------------
+//  -------------- BEGIN VARIABLES TO UPDATE ----------------
+//  ---------------------------------------------------------
+
+const mappId = '...';
+const bpiKey = '...';
+
+//  ---------------------------------------------------------
+//  -------------- END VARIABLES TO UPDATE ------------------
+//  ---------------------------------------------------------
+
+; (async () => {
+    try {
+        const overledger = new OverledgerSDK(mappId, bpiKey, {
+            dlts: [{ dlt: DltNameOptions.BITCOIN }, { dlt: DltNameOptions.ETHEREUM }, { dlt: DltNameOptions.XRP_LEDGER }],
+            provider: { network: 'testnet' , timeout: '1200000'},
+        });
+
+        let requestRipple = {
+            dlt: "ripple",
+            data: "0"
+        }
+
+        let requestBitcoin = {
+            dlt: "bitcoin",
+            data: "15"
+        }
+
+        let requestEthereum = {
+            dlt: "ethereum",
+            data: "0"
+        }
+
+        console.log("going to call fee estimation");
+        const feeEstimationResponseRipple = await overledger.getFeeEstimation(requestRipple.dlt, requestRipple.data);
+        const feeEstimationResponseBitcoin = await overledger.getFeeEstimation(requestBitcoin.dlt, requestBitcoin.data);
+        const feeEstimationResponseEthereum = await overledger.getFeeEstimation(requestEthereum.dlt, requestEthereum.data);
+
+        console.log("");
+        console.log('feeEstimationResponse for dlt: ' + feeEstimationResponseRipple.data.dlt + ", data:" + feeEstimationResponseRipple.data.data);
+        console.log('feeEstimationResponse for dlt: ' + feeEstimationResponseBitcoin.data.dlt + ", data:" + feeEstimationResponseBitcoin.data.data);
+        console.log('feeEstimationResponse for dlt: ' + feeEstimationResponseEthereum.data.dlt + ", data:" + feeEstimationResponseEthereum.data.data);
+        console.log("");
+
+    } catch (e) {
+        console.error('error', e);
+        //console.error('error', e.response.data.errors);
+    }
+})();

--- a/packages/overledger-core/src/OverledgerSDK.ts
+++ b/packages/overledger-core/src/OverledgerSDK.ts
@@ -2,7 +2,7 @@ import { AxiosInstance, AxiosPromise } from 'axios';
 import OverledgerSearch from '@quantnetwork/overledger-search';
 import Provider, { TESTNET } from '@quantnetwork/overledger-provider';
 import AbstractDLT from '@quantnetwork/overledger-dlt-abstract';
-import {StatusRequest, SignedTransactionRequest, SDKOptions, DLTOptions, TransactionRequest, SequenceDataRequest, APICallWrapper, DLTAndAddress, NetworkOptions, SequenceDataResponse } from '@quantnetwork/overledger-types';
+import {StatusRequest, SignedTransactionRequest, SDKOptions, DLTOptions, TransactionRequest, SequenceDataRequest, APICallWrapper, DLTAndAddress, NetworkOptions, SequenceDataResponse, FeeEstimationResponse  } from '@quantnetwork/overledger-types';
 /**
  * @memberof module:overledger-core
 */
@@ -196,6 +196,24 @@ class OverledgerSDK {
    */
   public readOverledgerTransaction(overledgerTransactionId: string): AxiosPromise<Object> {
     return this.request.get(`/transactions/id/${overledgerTransactionId}`);
+  }
+
+  /**
+   * Get the fee estimation for a DLT
+   * @param {string} address The address to query for
+   * @param {number} blockNumber The number of blocks
+   * @return {Promise<AxiosResponse>}
+   */
+  public getFeeEstimation(dlt: string, blockNumber: number): AxiosPromise<FeeEstimationResponse> {
+    if (dlt === '') {
+      throw new Error('The dlt name must be passed');
+    }
+
+    try {
+      return this.request.post(`/fee/${dlt}/${blockNumber}`);
+    } catch(e) {
+      return e.response;
+    }
   }
 
   /**

--- a/packages/overledger-types/src/FeeEstimationResponse.ts
+++ b/packages/overledger-types/src/FeeEstimationResponse.ts
@@ -1,0 +1,15 @@
+/**
+ * Fee estimation from different DLT
+ * @typedef {string} dlt name
+ * @property {object} data from the fee estimation call
+ */
+
+/**
+ * @memberof module:overledger-types
+ */
+type FeeEstimationResponse = {
+    dlt: string,
+    data: object,
+};
+
+export default FeeEstimationResponse;

--- a/packages/overledger-types/src/index.ts
+++ b/packages/overledger-types/src/index.ts
@@ -31,6 +31,7 @@ import InteropSCFunctionOptions from './associatedEnums/SCInteropOptions';
 import DltNameOptions from './associatedEnums/DltNameOptions';
 import ValidationCheck from './ValidationCheck';
 import StatusRequest from './StatusRequest';
+import FeeEstimationResponse from './FeeEstimationResponse';
 /**
  * Types used by the Overledger SDK packages.
  */
@@ -63,5 +64,6 @@ export {
   InteropSCFunctionOptions,
   DltNameOptions,
   ValidationCheck,
-  StatusRequest
+  StatusRequest,
+    FeeEstimationResponse
 };


### PR DESCRIPTION
as the revert was done, i am raising this new PR to keep the work active and to be merged back once ready.


This is related to the work for estimation fee function for different DLTs. A new general method can be used to query the fee, tickets covered should be:
https://app.clubhouse.io/squad2/story/11259/star-create-bitcoin-fee-estimation-function-in-java-sdk
https://app.clubhouse.io/squad2/story/11263/star-create-ripple-fee-estimation-function-in-java-sdk
https://app.clubhouse.io/squad2/story/11261/star-create-ethereum-fee-estimation-function-in-java-sdk

A new method is supplied via the Client and OverledgerSDK, getFeeEstimation. This should allow what fee roughly would cost a transaction for the next few blocks.

Method accepts DLT name and then the flow downstream will decide to communicate which dlt and return the response.